### PR TITLE
Correct raise statements to not use new.

### DIFF
--- a/lib/sandthorn/aggregate_root_snapshot.rb
+++ b/lib/sandthorn/aggregate_root_snapshot.rb
@@ -10,7 +10,7 @@ module Sandthorn
 
     def aggregate_snapshot!
       if @aggregate_events.count > 0
-        raise Errors::SnapshotError.new, 
+        raise Errors::SnapshotError,
           "Can't take snapshot on object with unsaved events"
       end
 
@@ -23,7 +23,7 @@ module Sandthorn
 
     def save_snapshot
       unless aggregate_snapshot
-        raise Errors::SnapshotError.new "No snapshot has been created!"
+        raise Errors::SnapshotError, "No snapshot has been created!"
       end
 
       @aggregate_snapshot[:event_data] = Sandthorn


### PR DESCRIPTION
Raise conditions that were changed have been corrected and the ones that were still using the old style have been corrected as well.
