### PR TITLE
Adding ability to use driver's find obsolete aggregates

### DIFF
--- a/lib/sandthorn.rb
+++ b/lib/sandthorn.rb
@@ -67,7 +67,7 @@ module Sandthorn
       events
     end
 
-    def aggregates_with_obsolete_snapshots type_names: [], min_event_distance: 0
+    def obsolete_snapshots type_names: [], min_event_distance: 0
       drivers = drivers_for_aggregate_types type_names: type_names
       obsolete = drivers.flat_map { |driver| driver.obsolete_snapshots(class_names: type_names, max_event_distance: min_event_distance) }
       yielder = []

--- a/spec/sandthorn_spec.rb
+++ b/spec/sandthorn_spec.rb
@@ -19,13 +19,13 @@ describe Sandthorn do
 
   context "when doing snapshots" do
     it "retrieves a list of obsolete snapshots" do
-      obsolete_aggregates = Sandthorn.aggregates_with_obsolete_snapshots type_names: [AnAggregate], min_event_distance: 0
+      obsolete_aggregates = Sandthorn.obsolete_snapshots type_names: [AnAggregate], min_event_distance: 0
       expect(obsolete_aggregates).to_not be_empty
     end
 
     it "accepts a block that is applied to each aggregate" do
       obsolete_aggregates = []
-      Sandthorn.aggregates_with_obsolete_snapshots type_names: [AnAggregate], min_event_distance: 0 do |aggr|
+      Sandthorn.obsolete_snapshots type_names: [AnAggregate], min_event_distance: 0 do |aggr|
         aggr.test_block_count = true
         obsolete_aggregates << aggr
       end
@@ -33,7 +33,7 @@ describe Sandthorn do
     end
 
     it "only retrieves aggregates older than min_event_distance" do
-      obsolete_aggregates = Sandthorn.aggregates_with_obsolete_snapshots type_names: [AnAggregate], min_event_distance: 10
+      obsolete_aggregates = Sandthorn.obsolete_snapshots type_names: [AnAggregate], min_event_distance: 10
       expect(obsolete_aggregates).to be_empty
     end
   end


### PR DESCRIPTION
This wraps the functionality already existing in Sandthorn's sequel driver. 
