### PR TITLE
Feature/custom serializers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sandthorn (0.5.0)
+    sandthorn (0.5.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Check out examples of Sandthorn:
 ## How do I use Sandthorn?
 
 
-
 Think of it as an object database where you store not only what the new value of an attribute is, but also when and why it changed.
 _Example:_
 
@@ -67,7 +66,9 @@ end
 # Setup the framework with the sequel driver for persistance
 url = "sqlite://spec/db/sequel_driver.sqlite3"
 catch_all_config = [ { driver: SandthornDriverSequel.driver_from_url(url: url) } ]
-Sandthorn.configuration = catch_all_config
+Sandthorn.configure do |sand|
+  sand.drivers = catch_all_config
+end
 
 # Migrate db schema for the sequel driver
 migrator = SandthornDriverSequel::Migration.new url: url
@@ -99,6 +100,8 @@ Or install it yourself as:
 
 # Configuring Sandthorn
 
+## Storage
+
 Sandthorn relies on a driver is specific to the data storage that you are using. This means Sandthorn can be used with any data storage given that a driver exists.
 
 To setup a driver you need to add it to your project's Gemfile and configure it in your application code.
@@ -109,9 +112,10 @@ The driver is configured when your application launches. Here's an example of ho
 
 ```ruby
 url = "sqlite://spec/db/sequel_driver.sqlite3"
-driver = SandthornDriverSequel.driver_from_url(url: url)
-catch_all_config = [ { driver: driver } ]
-Sandthorn.configuration = catch_all_config
+catch_all_config = [ { driver: SandthornDriverSequel.driver_from_url(url: url) } ]
+Sandthorn.configure do |sand|
+  sand.drivers = catch_all_config
+end
 ```
 
 First we specify the path to the sqlite3 database in the `url` variable. Secondly, the specific driver is instantiated with the `url`. Hence, the driver could be instantiated using a different configuration, for example, an address to a Postgres database. Finally, `Sandthorn.configure` accepts a keyword list with options. The only option which is required is `driver`.
@@ -127,6 +131,25 @@ SandthornDriverSequel.migrate_db url: url
 Optionally, when using Sandthorn in your tests you can configure it in a `spec_helper.rb` which is then required by your test suites [example](https://github.com/Sandthorn/sandthorn_examples/blob/master/sandthorn_tictactoe/spec/spec_helper.rb#L20-L30). Note that the Sequel driver accepts a special parameter to empty the database between each test.
 
 The Sequel driver is the only production-ready driver to date.
+
+## Custom serializer/deserializer
+
+The serializer and deserializer convert the event data to and from formats that can be stored.
+
+They can be customized by giving Sandthorn blocks like this:
+
+```ruby
+Sandthorn.configure do |s|
+  s.serializer do |data|
+    YAML.dump(data)
+  end
+  s.deserializer do |data|
+    YAML.load(data)
+  end
+end
+```
+
+YAML is the default serializer.
 
 # Usage
 

--- a/lib/sandthorn.rb
+++ b/lib/sandthorn.rb
@@ -4,28 +4,28 @@ require "sandthorn/configuration"
 require "sandthorn/aggregate_root"
 require 'yaml'
 require 'securerandom'
+require 'forwardable'
 
 module Sandthorn
   class << self
-    def configuration= configuration
-      @configuration = configuration
+    extend Forwardable
+
+    def_delegators :configuration, :drivers, :serializer, :deserializer
+
+    def configure
+      yield(configuration) if block_given?
     end
+
     def configuration
-      @configuration ||= []
+      @configuration ||= Sandthorn::Configuration.new
     end
 
     def serialize data
-      #Marshal.dump(data)
-      YAML::dump(data)
-      #Oj.dump(data)
-      #MessagePack.pack(data, symbolize_keys: true)
+      serializer.call(data)
     end
 
     def deserialize data
-      #Marshal.load(data)
-      YAML::load(data)
-      #Oj.load(data)
-      #MessagePack.unpack(data, symbolize_keys: true)
+      deserializer.call(data)
     end
 
     def generate_aggregate_id
@@ -91,7 +91,7 @@ module Sandthorn
       driver
     end
     def identify_driver_from_class class_name
-      matches = configuration.select do |conf|
+      matches = drivers.select do |conf|
         r = Regexp.new "^#{conf[:aggregate_pattern]}"
         pattern = class_name.to_s
         conf[:aggregate_pattern].nil? || r.match(pattern)
@@ -105,7 +105,7 @@ module Sandthorn
       type_names.map { |e| driver_for e }
     end
     def all_drivers
-      configuration.map { |e| e[:driver]  }
+      drivers.map { |e| e[:driver]  }
     end
   end
 end

--- a/lib/sandthorn.rb
+++ b/lib/sandthorn.rb
@@ -1,5 +1,6 @@
 require "sandthorn/version"
 require "sandthorn/errors"
+require "sandthorn/configuration"
 require "sandthorn/aggregate_root"
 require 'yaml'
 require 'securerandom'

--- a/lib/sandthorn/configuration.rb
+++ b/lib/sandthorn/configuration.rb
@@ -1,0 +1,34 @@
+module Sandthorn
+  class Configuration
+    attr_accessor :drivers
+
+    def initialize
+      yield(self) if block_given?
+    end
+
+    def serializer
+      if block_given?
+        @serializer = Proc.new
+      else
+        @serializer ||= default_serializer
+      end
+    end
+
+    def deserializer
+      if block_given?
+        @deserializer = Proc.new
+      else
+        @deserializer ||= default_deserializer
+      end
+    end
+
+    def default_serializer
+      @default_serializer   ||= -> (data) { YAML.dump(data) }
+    end
+
+    def default_deserializer
+      @default_deserializer ||= -> (data) { YAML.load(data) }
+    end
+
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Sandthorn::Configuration do
+  let(:config) { Sandthorn::Configuration.new }
+
+  shared_examples "block receiver" do |method, default_method|
+    context "when not given a block" do
+      context "and no block has ever been given" do
+        it "returns the default block" do
+          expect(config.send(method)).to eq(config.send(default_method))
+        end
+      end
+
+      context "when a block has been given" do
+        it "returns the given block" do
+          block = -> {}
+          config.send(method, &block)
+          expect(config.send(method)).to eq(block)
+        end
+      end
+    end
+  end
+
+  describe "#serializer" do
+    it_behaves_like "block receiver", :serializer, :default_serializer
+  end
+
+  describe "#deserializer" do
+    it_behaves_like "block receiver", :deserializer, :default_deserializer
+  end
+end

--- a/spec/sandthorn_spec.rb
+++ b/spec/sandthorn_spec.rb
@@ -37,4 +37,23 @@ describe Sandthorn do
       expect(obsolete_aggregates).to be_empty
     end
   end
+
+  describe "::serialize" do
+    it "delegates to the configured serializer" do
+      data = :data
+      serializer = Sandthorn.configuration.serializer
+      expect(serializer).to receive(:call).with(data)
+      Sandthorn.serialize(data)
+    end
+  end
+
+  describe "::deserialize" do
+    it "delegates to the configured deserializer" do
+      data = :data
+      deserializer = Sandthorn.configuration.deserializer
+      expect(deserializer).to receive(:call).with(data)
+      Sandthorn.deserialize(data)
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,9 @@ end
 def sqlite_store_setup
   url = spec_db 
   catch_all_config = [ { driver: SandthornDriverSequel.driver_from_url(url: url) } ]
-  Sandthorn.configuration = catch_all_config
+  Sandthorn.configure do |sand|
+    sand.drivers = catch_all_config
+  end
   migrator = SandthornDriverSequel::Migration.new url: url
   SandthornDriverSequel.migrate_db url: url
   migrator.send(:clear_for_test)


### PR DESCRIPTION
Make it easy to provide custom serializers/deserializers for event data. Default to YAML.

Uses the same kind of configuration pattern as PR #17, but brakes it out to a separate file.

See readme for usage.