### PR TITLE
added map_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,14 @@ Or install it yourself as:
 
 # Configuring Sandthorn
 
-Sandthorn relies on a driver is specific to the data storage that you are using. This means Sandthorn can be used with any data storage given that a driver exists.
+## Driver
+
+Sandthorn relies on a driver that is specific to the data storage that you are using. This means Sandthorn can be used with any data storage given that a driver exists.
 
 To setup a driver you need to add it to your project's Gemfile and configure it in your application code.
 
     gem 'sandthorn_driver_sequel'
+
 
 The driver is configured when your application launches. Here's an example of how to do it using the Sequel driver and a sqlite3 database.
 
@@ -147,6 +150,31 @@ SandthornDriverSequel.migrate_db url: url
 
 Optionally, when using Sandthorn in your tests you can configure it in a `spec_helper.rb` which is then required by your test suites [example](https://github.com/Sandthorn/sandthorn_examples/blob/master/sandthorn_tictactoe/spec/spec_helper.rb#L20-L30). Note that the Sequel driver accepts a special parameter to empty the database between each test.
 
+The Sequel driver is the only production-ready driver to date.
+
+
+## Map aggregate types to event stores
+
+Its possible to map aggregate_types to events stores from the configuration setup. This makes it possible to work with data from different stores that are using the same context, and will override any event_store setting within an aggregate.
+
+```ruby
+
+class AnAggregate
+  Include Sandthorn::AggregateRoot
+end
+
+class AnOtherAggregate
+  Include Sandthorn::AggregateRoot
+end
+
+Sandthorn.configure do |conf|
+  conf.event_stores = { foo: driver, bar: other_driver }
+  conf.map_types = { foo: [AnAggregate], bar: [AnOtherAggregate] }
+end
+```
+
+## Data serialization / deserialization
+
 Its possible to configure how events and snapshots are serialized / deserialized. The default are YAML but can be overloaded in the configure block.
 
 ```ruby
@@ -158,7 +186,6 @@ Sandthorn.configure do |conf|
 end
 ```
 
-The Sequel driver is the only production-ready driver to date.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ The Sequel driver is the only production-ready driver to date.
 Its possible to map aggregate_types to events stores from the configuration setup. This makes it possible to work with data from different stores that are using the same context, and will override any event_store setting within an aggregate.
 
 ```ruby
+url_foo = "sqlite://spec/db/sequel_driver_foo.sqlite3"
+driver_foo = SandthornDriverSequel.driver_from_url(url: url_foo)
+
+url_bar = "sqlite://spec/db/sequel_driver_bar.sqlite3"
+driver_bar = SandthornDriverSequel.driver_from_url(url: url_bar)
 
 class AnAggregate
   Include Sandthorn::AggregateRoot
@@ -168,7 +173,7 @@ class AnOtherAggregate
 end
 
 Sandthorn.configure do |conf|
-  conf.event_stores = { foo: driver, bar: other_driver }
+  conf.event_stores = { foo: driver_foo, bar: driver_bar }
   conf.map_types = { foo: [AnAggregate], bar: [AnOtherAggregate] }
 end
 ```

--- a/lib/sandthorn/event_stores.rb
+++ b/lib/sandthorn/event_stores.rb
@@ -40,13 +40,9 @@ module Sandthorn
       store_map.values
     end
 
-    def map_aggregate_type_to_event_store(aggregate_type, event_store)
-      aggregate_type.event_store(event_store)
-    end
-
-    def map_aggregate_types_to_event_store(aggregate_types = [], event_store)
-      aggregate_types.each do |aggregate_type|
-        map_aggregate_type_to_event_store(aggregate_type, event_store)
+    def map_types(hash)
+      hash.each_pair do |event_store, aggregate_types|
+        map_aggregate_types_to_event_store(aggregate_types, event_store)
       end
     end
 
@@ -68,6 +64,16 @@ module Sandthorn
 
     def is_event_store?(store)
       store.respond_to?(:get_events)
+    end
+
+    def map_aggregate_type_to_event_store(aggregate_type, event_store)
+      aggregate_type.event_store(event_store)
+    end
+
+    def map_aggregate_types_to_event_store(aggregate_types = [], event_store)
+      aggregate_types.each do |aggregate_type|
+        map_aggregate_type_to_event_store(aggregate_type, event_store)
+      end
     end
 
   end

--- a/lib/sandthorn/event_stores.rb
+++ b/lib/sandthorn/event_stores.rb
@@ -44,9 +44,9 @@ module Sandthorn
       aggregate_type.event_store(event_store)
     end
 
-    def map_aggregate_types_to_event_store(array = [])
-      array.each do |item|
-        map_aggregate_type_to_event_store(item[:aggregate_type], item[:event_store]) if(item[:aggregate_type] && item[:event_store])
+    def map_aggregate_types_to_event_store(aggregate_types = [], event_store)
+      aggregate_types.each do |aggregate_type|
+        map_aggregate_type_to_event_store(aggregate_type, event_store)
       end
     end
 

--- a/lib/sandthorn/event_stores.rb
+++ b/lib/sandthorn/event_stores.rb
@@ -40,13 +40,13 @@ module Sandthorn
       store_map.values
     end
 
-    def mapp_aggregate_type_to_event_store(aggregate_type, event_store)
+    def map_aggregate_type_to_event_store(aggregate_type, event_store)
       aggregate_type.event_store(event_store)
     end
 
-    def mapp_aggregate_types_to_event_store(array = [])
+    def map_aggregate_types_to_event_store(array = [])
       array.each do |item|
-        mapp_aggregate_type_to_event_store(item[:aggregate_type], item[:event_store]) if(item[:aggregate_type] && item[:event_store])
+        map_aggregate_type_to_event_store(item[:aggregate_type], item[:event_store]) if(item[:aggregate_type] && item[:event_store])
       end
     end
 

--- a/lib/sandthorn/event_stores.rb
+++ b/lib/sandthorn/event_stores.rb
@@ -40,6 +40,16 @@ module Sandthorn
       store_map.values
     end
 
+    def mapp_aggregate_type_to_event_store(aggregate_type, event_store)
+      aggregate_type.event_store(event_store)
+    end
+
+    def mapp_aggregate_types_to_event_store(array = [])
+      array.each do |item|
+        mapp_aggregate_type_to_event_store(item[:aggregate_type], item[:event_store]) if(item[:aggregate_type] && item[:event_store])
+      end
+    end
+
     private
 
     attr_reader :store_map

--- a/spec/event_stores_spec.rb
+++ b/spec/event_stores_spec.rb
@@ -4,6 +4,13 @@ module Sandthorn
   describe EventStores do
     let(:stores) { EventStores.new }
 
+    before do
+      class AnAggregate 
+        include Sandthorn::AggregateRoot
+      end
+    end
+    
+
     describe "#initialize" do
       context "when given a single event_store" do
         it "sets it as the default event store" do
@@ -75,6 +82,38 @@ module Sandthorn
         store = double
         stores.add(:foo, store)
         expect(stores[:foo]).to eq(store)
+      end
+    end
+
+    describe "#mapp_aggregate_type_to_event_store" do
+
+      let(:klass) {
+        class AnAggregate 
+          include Sandthorn::AggregateRoot
+        end
+      }
+
+      it "mapps the aggregate_type to the event_store" do
+        store = double
+        stores.add(:foo, store)
+        stores.mapp_aggregate_type_to_event_store(klass, :foo)
+        expect(klass.event_store).to eq(:foo)
+      end
+    end
+
+    describe "#mapp_aggregate_types_to_event_store" do
+
+      let(:klass) {
+        class AnAggregate 
+          include Sandthorn::AggregateRoot
+        end
+      }
+
+      it "mapps an array of aggregate_types to event_stores" do
+        store = double
+        stores.add(:foo, store)
+        stores.mapp_aggregate_types_to_event_store([{ aggregate_type: klass, event_store: :foo }])
+        expect(klass.event_store).to eq(:foo)
       end
     end
   end

--- a/spec/event_stores_spec.rb
+++ b/spec/event_stores_spec.rb
@@ -96,7 +96,7 @@ module Sandthorn
       it "maps the aggregate_type to the event_store" do
         store = double
         stores.add(:foo, store)
-        stores.map_aggregate_type_to_event_store(klass, :foo)
+        stores.map_types(foo: [klass])
         expect(klass.event_store).to eq(:foo)
       end
     end
@@ -112,7 +112,7 @@ module Sandthorn
       it "maps an array of aggregate_types to event_stores" do
         store = double
         stores.add(:foo, store)
-        stores.map_aggregate_types_to_event_store([klass], :foo)
+        stores.map_types(foo: [klass])
         expect(klass.event_store).to eq(:foo)
       end
     end

--- a/spec/event_stores_spec.rb
+++ b/spec/event_stores_spec.rb
@@ -112,7 +112,7 @@ module Sandthorn
       it "maps an array of aggregate_types to event_stores" do
         store = double
         stores.add(:foo, store)
-        stores.map_aggregate_types_to_event_store([{ aggregate_type: klass, event_store: :foo }])
+        stores.map_aggregate_types_to_event_store([klass], :foo)
         expect(klass.event_store).to eq(:foo)
       end
     end

--- a/spec/event_stores_spec.rb
+++ b/spec/event_stores_spec.rb
@@ -85,7 +85,7 @@ module Sandthorn
       end
     end
 
-    describe "#mapp_aggregate_type_to_event_store" do
+    describe "#map_aggregate_type_to_event_store" do
 
       let(:klass) {
         class AnAggregate 
@@ -93,15 +93,15 @@ module Sandthorn
         end
       }
 
-      it "mapps the aggregate_type to the event_store" do
+      it "maps the aggregate_type to the event_store" do
         store = double
         stores.add(:foo, store)
-        stores.mapp_aggregate_type_to_event_store(klass, :foo)
+        stores.map_aggregate_type_to_event_store(klass, :foo)
         expect(klass.event_store).to eq(:foo)
       end
     end
 
-    describe "#mapp_aggregate_types_to_event_store" do
+    describe "#map_aggregate_types_to_event_store" do
 
       let(:klass) {
         class AnAggregate 
@@ -109,10 +109,10 @@ module Sandthorn
         end
       }
 
-      it "mapps an array of aggregate_types to event_stores" do
+      it "maps an array of aggregate_types to event_stores" do
         store = double
         stores.add(:foo, store)
-        stores.mapp_aggregate_types_to_event_store([{ aggregate_type: klass, event_store: :foo }])
+        stores.map_aggregate_types_to_event_store([{ aggregate_type: klass, event_store: :foo }])
         expect(klass.event_store).to eq(:foo)
       end
     end

--- a/spec/event_stores_spec.rb
+++ b/spec/event_stores_spec.rb
@@ -85,36 +85,34 @@ module Sandthorn
       end
     end
 
-    describe "#map_aggregate_type_to_event_store" do
+    describe "#map_types" do
 
-      let(:klass) {
-        class AnAggregate 
+      context "map two events stores" do
+        
+        class AnAggregate1
           include Sandthorn::AggregateRoot
         end
-      }
 
-      it "maps the aggregate_type to the event_store" do
-        store = double
-        stores.add(:foo, store)
-        stores.map_types(foo: [klass])
-        expect(klass.event_store).to eq(:foo)
+        class AnAggregate2
+          include Sandthorn::AggregateRoot
+        end
+
+        before do
+          store = double
+          stores.add(:foo, store)
+          stores.add(:bar, store)
+          stores.map_types(foo: [AnAggregate1], bar: [AnAggregate2])
+        end
+
+        it "should map event_store foo to AnAggregate1" do
+          expect(AnAggregate1.event_store).to eq(:foo)
+        end
+
+        it "should map event_store bar to AnAggregate2" do
+          expect(AnAggregate2.event_store).to eq(:bar)
+        end
       end
     end
 
-    describe "#map_aggregate_types_to_event_store" do
-
-      let(:klass) {
-        class AnAggregate 
-          include Sandthorn::AggregateRoot
-        end
-      }
-
-      it "maps an array of aggregate_types to event_stores" do
-        store = double
-        stores.add(:foo, store)
-        stores.map_types(foo: [klass])
-        expect(klass.event_store).to eq(:foo)
-      end
-    end
   end
 end

--- a/spec/get_events_spec.rb
+++ b/spec/get_events_spec.rb
@@ -66,7 +66,7 @@ describe Sandthorn do
     url = "sqlite://spec/db/other_db.sqlite3"
     driver = SandthornDriverSequel.driver_from_url(url: url)
     Sandthorn.event_stores.add(:other, driver)
-    Sandthorn.event_stores.mapp_aggregate_type_to_event_store(AnotherAggregate, :other)
+    Sandthorn.event_stores.map_aggregate_type_to_event_store(AnotherAggregate, :other)
     migrator = SandthornDriverSequel::Migration.new url: url
     SandthornDriverSequel.migrate_db url: url
     migrator.send(:clear_for_test)

--- a/spec/get_events_spec.rb
+++ b/spec/get_events_spec.rb
@@ -6,7 +6,7 @@ end
 
 class AnotherAggregate
   include Sandthorn::AggregateRoot
-  event_store :other
+  event_store :should_override_this
 end
 
 describe Sandthorn do
@@ -66,6 +66,7 @@ describe Sandthorn do
     url = "sqlite://spec/db/other_db.sqlite3"
     driver = SandthornDriverSequel.driver_from_url(url: url)
     Sandthorn.event_stores.add(:other, driver)
+    Sandthorn.event_stores.mapp_aggregate_type_to_event_store(AnotherAggregate, :other)
     migrator = SandthornDriverSequel::Migration.new url: url
     SandthornDriverSequel.migrate_db url: url
     migrator.send(:clear_for_test)

--- a/spec/get_events_spec.rb
+++ b/spec/get_events_spec.rb
@@ -66,7 +66,7 @@ describe Sandthorn do
     url = "sqlite://spec/db/other_db.sqlite3"
     driver = SandthornDriverSequel.driver_from_url(url: url)
     Sandthorn.event_stores.add(:other, driver)
-    Sandthorn.event_stores.map_aggregate_type_to_event_store(AnotherAggregate, :other)
+    Sandthorn.event_stores.map_types(other: [AnotherAggregate])
     migrator = SandthornDriverSequel::Migration.new url: url
     SandthornDriverSequel.migrate_db url: url
     migrator.send(:clear_for_test)


### PR DESCRIPTION
This setting makes it possible to direct a aggregate to an event_store when Sandthorn is configured.
It will override the current event_store property on the aggregate.