### PR TITLE
aggregate_list in bounded context

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,9 @@ In this case, the resulting events from the commands `new` and `mark` will have 
 
 ## Bounded Context
 
-A bounded context is a system divider that split large systems into smaller parts. [Bounded Context](http://martinfowler.com/bliki/BoundedContext.html) by Martin Fowler
+A bounded context is a system divider that split large systems into smaller parts. [Bounded Context by Martin Fowler](http://martinfowler.com/bliki/BoundedContext.html) 
 
-A module can include `Sandthorn::BoundedContext` and all aggregates within the module can be retreived via the ::aggregate_list method on the module. A use case is to use it when Sandthorn is configured and setup a bounded context with a driver.
+A module can include `Sandthorn::BoundedContext` and all aggregates within the module can be retreived via the ::aggregate_list method on the module. A use case is to use it when Sandthorn is configured and setup all aggregates in a bounded context to a driver.
 
 ```ruby
 require 'sandthorn/bounded_context'

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ The Sequel driver is the only production-ready driver to date.
 
 # Usage
 
+## Aggregate Root
+
 Any object that should have event sourcing capability must include the methods provided by `Sandthorn::AggregateRoot`. These make it possible to `commit` events and `save` changes to an aggregate. Use the `include` directive as follows:
 
 ```ruby
@@ -251,6 +253,30 @@ end
 
 In this case, the resulting events from the commands `new` and `mark` will have the trace `{ip: :127.0.0.1}` attached to them.
 
+## Bounded Context
+
+A bounded context is a system divider that split large systems into smaller parts. [Bounded Context](http://martinfowler.com/bliki/BoundedContext.html) by Martin Fowler
+
+A module can include `Sandthorn::BoundedContext` and all aggregates within the module can be retreived via the ::aggregate_list method on the module. A use case is to use it when Sandthorn is configured and setup a bounded context with a driver.
+
+```ruby
+require 'sandthorn/bounded_context'
+
+module TicTacToe
+  include Sandthorn::BoundedContext
+
+  class Board
+    include Sandthorn::AggregateRoot
+  end
+end
+
+Sandthorn.configure do |conf|
+  conf.event_stores = { foo: driver_foo}
+  conf.map_types = { foo: TicTacToe.aggregate_list }
+end
+
+TicTacToe.aggregate_list -> [TicTacToy::Board]
+```
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ In this case, the resulting events from the commands `new` and `mark` will have 
 
 A bounded context is a system divider that split large systems into smaller parts. [Bounded Context by Martin Fowler](http://martinfowler.com/bliki/BoundedContext.html) 
 
-A module can include `Sandthorn::BoundedContext` and all aggregates within the module can be retreived via the ::aggregate_list method on the module. A use case is to use it when Sandthorn is configured and setup all aggregates in a bounded context to a driver.
+A module can include `Sandthorn::BoundedContext` and all aggregates within the module can be retreived via the ::aggregate_types method on the module. A use case is to use it when Sandthorn is configured and setup all aggregates in a bounded context to a driver.
 
 ```ruby
 require 'sandthorn/bounded_context'
@@ -272,10 +272,10 @@ end
 
 Sandthorn.configure do |conf|
   conf.event_stores = { foo: driver_foo}
-  conf.map_types = { foo: TicTacToe.aggregate_list }
+  conf.map_types = { foo: TicTacToe.aggregate_types }
 end
 
-TicTacToe.aggregate_list -> [TicTacToy::Board]
+TicTacToe.aggregate_types -> [TicTacToy::Board]
 ```
 
 # Development

--- a/lib/sandthorn/bounded_context.rb
+++ b/lib/sandthorn/bounded_context.rb
@@ -1,12 +1,12 @@
 module Sandthorn
   module BoundedContext
-
     module ClassMethods
       def aggregate_list()
         @aggregate_list = p_aggregate_list(self)
       end
 
       private
+      
       def p_aggregate_list(bounded_context_module)
         return [] unless bounded_context_module.respond_to?(:constants)
         
@@ -30,6 +30,5 @@ module Sandthorn
     def self.included( other )
       other.extend( ClassMethods )
     end
-
   end
 end

--- a/lib/sandthorn/bounded_context.rb
+++ b/lib/sandthorn/bounded_context.rb
@@ -9,22 +9,27 @@ module Sandthorn
       private
       def p_aggregate_list(bounded_context_module)
         return [] unless bounded_context_module.respond_to?(:constants)
+        
         classes = bounded_context_module.constants.map(&bounded_context_module.method(:const_get)).grep(Class)
         aggregate_list = classes.select { |item| item.include?(Sandthorn::AggregateRoot) }
 
-        modules = bounded_context_module.constants.map(&bounded_context_module.method(:const_get)).grep(Module).delete_if do |mo| classes.include?(mo) || mo == Sandthorn::BoundedContext::ClassMethods end
+        modules = bounded_context_module.constants.map(&bounded_context_module.method(:const_get)).grep(Module).delete_if do |mo| 
+          classes.include?(mo) || mo == Sandthorn::BoundedContext::ClassMethods
+        end
+        
         modules.each do |mo|
           aggregate_list.concat(p_aggregate_list(mo))
         end
+        
         aggregate_list
       end
     end
 
     extend ClassMethods
+    
     def self.included( other )
       other.extend( ClassMethods )
     end
-    
 
   end
 end

--- a/lib/sandthorn/bounded_context.rb
+++ b/lib/sandthorn/bounded_context.rb
@@ -1,29 +1,29 @@
 module Sandthorn
   module BoundedContext
     module ClassMethods
-      def aggregate_list
-        @aggregate_list = p_aggregate_list(self)
+      def aggregate_types
+        @aggregate_list = p_aggregate_types(self)
       end
 
       private
       
-      def p_aggregate_list(bounded_context_module)
+      def p_aggregate_types(bounded_context_module)
         return [] unless bounded_context_module.respond_to?(:constants)
         
-        classes = get_classes(bounded_context_module)
+        classes = classes_in(bounded_context_module)
         aggregate_list = classes.select { |item| item.include?(Sandthorn::AggregateRoot) }
-        modules = get_modules(bounded_context_module, classes)
+        modules = modules_in(bounded_context_module, classes)
         
-        aggregate_list += modules.flat_map { |m| p_aggregate_list(m) }
+        aggregate_list += modules.flat_map { |m| p_aggregate_types(m) }
         
         aggregate_list
       end
 
-      def get_classes namespace
+      def classes_in(namespace)
         namespace.constants.map(&namespace.method(:const_get)).grep(Class)
       end
 
-      def get_modules namespace, classes
+      def modules_in(namespace, classes)
         namespace.constants.map(&namespace.method(:const_get)).grep(Module).delete_if do |m| 
           classes.include?(m) || m == Sandthorn::BoundedContext::ClassMethods
         end

--- a/lib/sandthorn/bounded_context.rb
+++ b/lib/sandthorn/bounded_context.rb
@@ -1,7 +1,7 @@
 module Sandthorn
   module BoundedContext
     module ClassMethods
-      def aggregate_list()
+      def aggregate_list
         @aggregate_list = p_aggregate_list(self)
       end
 

--- a/lib/sandthorn/bounded_context.rb
+++ b/lib/sandthorn/bounded_context.rb
@@ -13,11 +13,11 @@ module Sandthorn
         classes = bounded_context_module.constants.map(&bounded_context_module.method(:const_get)).grep(Class)
         aggregate_list = classes.select { |item| item.include?(Sandthorn::AggregateRoot) }
 
-        modules = bounded_context_module.constants.map(&bounded_context_module.method(:const_get)).grep(Module).delete_if do |mo| 
-          classes.include?(mo) || mo == Sandthorn::BoundedContext::ClassMethods
+        modules = bounded_context_module.constants.map(&bounded_context_module.method(:const_get)).grep(Module).delete_if do |m| 
+          classes.include?(m) || m == Sandthorn::BoundedContext::ClassMethods
         end
         
-        aggregate_list += modules.flat_map { |mo| p_aggregate_list(mo) }
+        aggregate_list += modules.flat_map { |m| p_aggregate_list(m) }
         
         aggregate_list
       end

--- a/lib/sandthorn/bounded_context.rb
+++ b/lib/sandthorn/bounded_context.rb
@@ -1,0 +1,30 @@
+module Sandthorn
+  module BoundedContext
+
+    module ClassMethods
+      def aggregate_list()
+        @aggregate_list = p_aggregate_list(self)
+      end
+
+      private
+      def p_aggregate_list(bounded_context_module)
+        return [] unless bounded_context_module.respond_to?(:constants)
+        classes = bounded_context_module.constants.map(&bounded_context_module.method(:const_get)).grep(Class)
+        aggregate_list = classes.select { |item| item.include?(Sandthorn::AggregateRoot) }
+
+        modules = bounded_context_module.constants.map(&bounded_context_module.method(:const_get)).grep(Module).delete_if do |mo| classes.include?(mo) || mo == Sandthorn::BoundedContext::ClassMethods end
+        modules.each do |mo|
+          aggregate_list.concat(p_aggregate_list(mo))
+        end
+        aggregate_list
+      end
+    end
+
+    extend ClassMethods
+    def self.included( other )
+      other.extend( ClassMethods )
+    end
+    
+
+  end
+end

--- a/lib/sandthorn/bounded_context.rb
+++ b/lib/sandthorn/bounded_context.rb
@@ -10,16 +10,23 @@ module Sandthorn
       def p_aggregate_list(bounded_context_module)
         return [] unless bounded_context_module.respond_to?(:constants)
         
-        classes = bounded_context_module.constants.map(&bounded_context_module.method(:const_get)).grep(Class)
+        classes = get_classes(bounded_context_module)
         aggregate_list = classes.select { |item| item.include?(Sandthorn::AggregateRoot) }
-
-        modules = bounded_context_module.constants.map(&bounded_context_module.method(:const_get)).grep(Module).delete_if do |m| 
-          classes.include?(m) || m == Sandthorn::BoundedContext::ClassMethods
-        end
+        modules = get_modules(bounded_context_module, classes)
         
         aggregate_list += modules.flat_map { |m| p_aggregate_list(m) }
         
         aggregate_list
+      end
+
+      def get_classes namespace
+        namespace.constants.map(&namespace.method(:const_get)).grep(Class)
+      end
+
+      def get_modules namespace, classes
+        namespace.constants.map(&namespace.method(:const_get)).grep(Module).delete_if do |m| 
+          classes.include?(m) || m == Sandthorn::BoundedContext::ClassMethods
+        end
       end
     end
 

--- a/lib/sandthorn/bounded_context.rb
+++ b/lib/sandthorn/bounded_context.rb
@@ -17,9 +17,7 @@ module Sandthorn
           classes.include?(mo) || mo == Sandthorn::BoundedContext::ClassMethods
         end
         
-        modules.each do |mo|
-          aggregate_list.concat(p_aggregate_list(mo))
-        end
+        aggregate_list += modules.flat_map { |mo| p_aggregate_list(mo) }
         
         aggregate_list
       end

--- a/spec/bounded_context_spec.rb
+++ b/spec/bounded_context_spec.rb
@@ -4,8 +4,8 @@ require 'sandthorn/bounded_context'
 module Sandthorn
   describe BoundedContext do
   
-    it 'should responde to aggregate_list' do
-      expect(BoundedContext.respond_to?(:aggregate_list)).to be_truthy
+    it 'should respond to `aggregate_list`' do
+      expect(BoundedContext).to respond_to(:aggregate_list)
     end
   end
 
@@ -39,7 +39,5 @@ module Sandthorn
     it "aggregate_list should include DeepAnAggregate in a nested Module" do
       expect(TestModule.aggregate_list).to include(TestModule::Deep::DeepAggregate)
     end
-
-
   end
 end

--- a/spec/bounded_context_spec.rb
+++ b/spec/bounded_context_spec.rb
@@ -3,14 +3,12 @@ require 'sandthorn/bounded_context'
 
 module Sandthorn
   describe BoundedContext do
-  
     it 'should respond to `aggregate_list`' do
       expect(BoundedContext).to respond_to(:aggregate_list)
     end
   end
 
   describe "::aggregate_list" do
-    
     module TestModule
       include Sandthorn::BoundedContext
       class AnAggregate 
@@ -26,7 +24,6 @@ module Sandthorn
         end
       end
     end
-
 
     it "aggregate_list should include AnAggregate" do
       expect(TestModule.aggregate_list).to include(TestModule::AnAggregate)

--- a/spec/bounded_context_spec.rb
+++ b/spec/bounded_context_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'sandthorn/bounded_context'
+
+module Sandthorn
+  describe BoundedContext do
+  
+    it 'should responde to aggregate_list' do
+      expect(BoundedContext.respond_to?(:aggregate_list)).to be_truthy
+    end
+  end
+
+  describe "::aggregate_list" do
+    
+    module TestModule
+      include Sandthorn::BoundedContext
+      class AnAggregate 
+        include Sandthorn::AggregateRoot
+      end
+
+      class NotAnAggregate
+      end
+
+      module Deep
+        class DeepAggregate
+          include Sandthorn::AggregateRoot
+        end
+      end
+    end
+
+    context "when namespace holds one aggregate" do
+
+      it "aggregate_list should include AnAggregate" do
+        expect(TestModule.aggregate_list).to include(TestModule::AnAggregate)
+      end
+
+      it "aggregate_list should not include NotAnAggregate" do
+        expect(TestModule.aggregate_list).not_to include(TestModule::NotAnAggregate)
+      end
+
+      it "aggregate_list should include DeepAnAggregate in a nested Module" do
+        expect(TestModule.aggregate_list).to include(TestModule::Deep::DeepAggregate)
+      end
+
+    end
+
+  end
+end

--- a/spec/bounded_context_spec.rb
+++ b/spec/bounded_context_spec.rb
@@ -3,12 +3,12 @@ require 'sandthorn/bounded_context'
 
 module Sandthorn
   describe BoundedContext do
-    it 'should respond to `aggregate_list`' do
-      expect(BoundedContext).to respond_to(:aggregate_list)
+    it 'should respond to `aggregate_types`' do
+      expect(BoundedContext).to respond_to(:aggregate_types)
     end
   end
 
-  describe "::aggregate_list" do
+  describe "::aggregate_types" do
     module TestModule
       include Sandthorn::BoundedContext
       class AnAggregate 
@@ -25,16 +25,16 @@ module Sandthorn
       end
     end
 
-    it "aggregate_list should include AnAggregate" do
-      expect(TestModule.aggregate_list).to include(TestModule::AnAggregate)
+    it "aggregate_types should include AnAggregate" do
+      expect(TestModule.aggregate_types).to include(TestModule::AnAggregate)
     end
 
-    it "aggregate_list should not include NotAnAggregate" do
-      expect(TestModule.aggregate_list).not_to include(TestModule::NotAnAggregate)
+    it "aggregate_types should not include NotAnAggregate" do
+      expect(TestModule.aggregate_types).not_to include(TestModule::NotAnAggregate)
     end
 
-    it "aggregate_list should include DeepAnAggregate in a nested Module" do
-      expect(TestModule.aggregate_list).to include(TestModule::Deep::DeepAggregate)
+    it "aggregate_types should include DeepAnAggregate in a nested Module" do
+      expect(TestModule.aggregate_types).to include(TestModule::Deep::DeepAggregate)
     end
   end
 end

--- a/spec/bounded_context_spec.rb
+++ b/spec/bounded_context_spec.rb
@@ -27,21 +27,19 @@ module Sandthorn
       end
     end
 
-    context "when namespace holds one aggregate" do
 
-      it "aggregate_list should include AnAggregate" do
-        expect(TestModule.aggregate_list).to include(TestModule::AnAggregate)
-      end
-
-      it "aggregate_list should not include NotAnAggregate" do
-        expect(TestModule.aggregate_list).not_to include(TestModule::NotAnAggregate)
-      end
-
-      it "aggregate_list should include DeepAnAggregate in a nested Module" do
-        expect(TestModule.aggregate_list).to include(TestModule::Deep::DeepAggregate)
-      end
-
+    it "aggregate_list should include AnAggregate" do
+      expect(TestModule.aggregate_list).to include(TestModule::AnAggregate)
     end
+
+    it "aggregate_list should not include NotAnAggregate" do
+      expect(TestModule.aggregate_list).not_to include(TestModule::NotAnAggregate)
+    end
+
+    it "aggregate_list should include DeepAnAggregate in a nested Module" do
+      expect(TestModule.aggregate_list).to include(TestModule::Deep::DeepAggregate)
+    end
+
 
   end
 end


### PR DESCRIPTION
Stared to implement the DDD concept Bounded Context. The aggregate_list will return all AggregateRoots in a BoundedContext module.

The idea is to use it together with the global configuration map_types to make it easier to list all aggregates in a bounded context and add then to an event store.