### PR TITLE
Default attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,18 @@ class Board
 end
 ```
 
+### `Sandthorn::AggregateRoot::default_attributes`
+
+Its possible to add a default_attributes method on an aggregate and set default values to new and already created aggregates.
+
+The default_attributes method will be run before initialize on Class.new and before the events when an aggregate is rebuilt. This will make is possible to add default attributes to an aggregate during its hole life cycle.
+
+```ruby
+def default_attributes
+  @new_array = []
+end
+```
+
 ### `Sandthorn::AggregateRoot.commit`
 
 It is required that an event is commited to the aggregate to be stored as an event. `commit` extracts the object's delta and locally caches the state changes that has been applied to the aggregate. Commonly, commit is called when an event is applied. In [CQRS](http://martinfowler.com/bliki/CQRS.html), events are named using past tense.

--- a/lib/sandthorn/aggregate_root_base.rb
+++ b/lib/sandthorn/aggregate_root_base.rb
@@ -52,6 +52,10 @@ module Sandthorn
         commit_with_event_name(event_name, args)
       end
 
+      def default_attributes
+        #NOOP
+      end
+
       alias :record_event :commit
 
       module ClassMethods
@@ -104,7 +108,7 @@ module Sandthorn
           aggregate.aggregate_base_initialize
           aggregate.aggregate_initialize
 
-          aggregate.default_attributes if aggregate.respond_to?(:default_attributes)
+          aggregate.default_attributes
           aggregate.send :initialize, *args, &block 
           aggregate.send :set_aggregate_id, Sandthorn.generate_aggregate_id
 
@@ -114,6 +118,8 @@ module Sandthorn
           end
 
         end
+
+
 
         def aggregate_build events
           current_aggregate_version = 0
@@ -129,7 +135,7 @@ module Sandthorn
           attributes = build_instance_vars_from_events events
           current_aggregate_version = events.last[:aggregate_version] unless events.empty?
           aggregate.send :clear_aggregate_events
-          aggregate.default_attributes if aggregate.respond_to?(:default_attributes)
+          aggregate.default_attributes
           aggregate.send :set_orginating_aggregate_version!, current_aggregate_version
           aggregate.send :set_current_aggregate_version!, current_aggregate_version
           aggregate.send :aggregate_initialize

--- a/lib/sandthorn/aggregate_root_base.rb
+++ b/lib/sandthorn/aggregate_root_base.rb
@@ -101,15 +101,14 @@ module Sandthorn
         def new *args, &block
 
           aggregate = allocate
+          aggregate.aggregate_base_initialize
+          aggregate.aggregate_initialize
+
           aggregate.default_attributes if aggregate.respond_to?(:default_attributes)
           aggregate.send :initialize, *args, &block 
-          
+          aggregate.send :set_aggregate_id, Sandthorn.generate_aggregate_id
+
           aggregate.aggregate_trace @@aggregate_trace_information do |aggr|
-            
-            aggr.aggregate_base_initialize
-            aggr.aggregate_initialize
-            
-            aggr.send :set_aggregate_id, Sandthorn.generate_aggregate_id
             aggr.send :commit, *args
             return aggr
           end

--- a/spec/default_attributes_spec.rb
+++ b/spec/default_attributes_spec.rb
@@ -5,20 +5,35 @@ class DefaultAttributes
   def initialize 
   end
 end
-def add_default_attributes
-  DefaultAttributes.class_eval do
-    attr_reader :array
-    define_method :default_attributes, lambda { @array = [] }
-  end
-end
+
+
 describe "when the initialize-method changes" do
-  it "should be possible to replay anyway" do
-    aggregate = DefaultAttributes.new 
-    events = aggregate.aggregate_events
-    add_default_attributes
-    with_change = DefaultAttributes.new
-    expect(with_change.array).to eql []
-    replayed = DefaultAttributes.aggregate_build(events)
-    expect(replayed.array).to eql []
+
+  it "should not have an array attribute on first version of the DefaultAttributes class" do
+    aggregate = DefaultAttributes.new
+    expect(aggregate.respond_to?(:array)).to be_falsy
+  end
+
+  context "default_attributes" do
+
+    def add_default_attributes
+      DefaultAttributes.class_eval do
+        attr_reader :array
+        define_method :default_attributes, lambda { @array = [] }
+      end
+    end
+
+    it "should have set the array attribute to [] on rebuilt " do
+      aggregate = DefaultAttributes.new
+      add_default_attributes
+      rebuilt_aggregate = DefaultAttributes.aggregate_build(aggregate.aggregate_events)
+      expect(rebuilt_aggregate.array).to eql []
+    end
+
+    it "should have an set the array attribute to [] on new" do
+      add_default_attributes
+      aggregate = DefaultAttributes.new
+      expect(aggregate.array).to eql []
+    end
   end
 end

--- a/spec/default_attributes_spec.rb
+++ b/spec/default_attributes_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+class DefaultAttributes
+  include Sandthorn::AggregateRoot
+  def initialize 
+  end
+end
+def add_default_attributes
+  DefaultAttributes.class_eval do
+    attr_reader :array
+    define_method :default_attributes, lambda { @array = [] }
+  end
+end
+describe "when the initialize-method changes" do
+  it "should be possible to replay anyway" do
+    aggregate = DefaultAttributes.new 
+    events = aggregate.aggregate_events
+    add_default_attributes
+    with_change = DefaultAttributes.new
+    expect(with_change.array).to eql []
+    replayed = DefaultAttributes.aggregate_build(events)
+    expect(replayed.array).to eql []
+  end
+end


### PR DESCRIPTION
Issue #43

Its possible to add a default_attributes function in an AggregateRoot and set default values to already created aggregates.

Ex: After a aggregate is created its possible to add default values that will be set when the aggregate is rebuilt.