### PR TITLE
use the .all and .find methods from driver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sandthorn.gemspec
 gemspec
+gem 'sandthorn_driver_sequel', git: 'https://github.com/Sandthorn/sandthorn_driver_sequel.git', branch: 'improve_event_store_api'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sandthorn.gemspec
 gemspec
-gem 'sandthorn_driver_sequel', git: 'https://github.com/Sandthorn/sandthorn_driver_sequel.git', branch: 'improve_event_store_api'

--- a/lib/sandthorn.rb
+++ b/lib/sandthorn.rb
@@ -52,6 +52,14 @@ module Sandthorn
       event_store_for(aggregate_type).get_aggregate_ids(aggregate_type: aggregate_type)
     end
 
+    def all aggregate_type
+      event_store_for(aggregate_type).all(aggregate_type)
+    end
+
+    def find aggregate_id, aggregate_type
+      event_store_for(aggregate_type).find(aggregate_id)
+    end
+
     def get_events event_store: :default, aggregate_types: [], take: 0, after_sequence_number: 0
       event_store = find_event_store(event_store)
       events = event_store.get_events aggregate_types: aggregate_types, take: take, after_sequence_number: after_sequence_number

--- a/lib/sandthorn/aggregate_root_base.rb
+++ b/lib/sandthorn/aggregate_root_base.rb
@@ -72,8 +72,9 @@ module Sandthorn
         end
 
         def all
-          aggregate_id_list = Sandthorn.get_aggregate_list_by_type(self)
-          find aggregate_id_list
+          Sandthorn.all(self).map { |events| 
+            aggregate_build events 
+          }
         end
 
         def find id
@@ -82,7 +83,7 @@ module Sandthorn
         end
 
         def aggregate_find aggregate_id
-          events = Sandthorn.get_aggregate(aggregate_id, self)
+          events = Sandthorn.find(aggregate_id, self)
           unless events && !events.empty?
             raise Sandthorn::Errors::AggregateNotFound
           end

--- a/sandthorn.gemspec
+++ b/sandthorn.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "autotest-standalone"
   spec.add_development_dependency "sqlite3"  
   spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "sandthorn_driver_sequel", ">= 3.0"
+ # spec.add_development_dependency "sandthorn_driver_sequel", ">= 3.0"
 end

--- a/sandthorn.gemspec
+++ b/sandthorn.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "autotest-standalone"
   spec.add_development_dependency "sqlite3"  
   spec.add_development_dependency "coveralls"
- # spec.add_development_dependency "sandthorn_driver_sequel", ">= 3.0"
+  spec.add_development_dependency "sandthorn_driver_sequel", ">= 3.1"
 end


### PR DESCRIPTION
Using the new .all and .find methods in the latest sandthorn_driver_sequel.